### PR TITLE
refactor: move static inline styles in snippet to classes

### DIFF
--- a/snippets/gallery.php
+++ b/snippets/gallery.php
@@ -1,9 +1,30 @@
 <?php if ($prev === null || $prev->type() !== 'gallery'): ?>
-    <div class="k-gallery-block" itemscope itemtype="http://schema.org/ImageGallery" style="margin-top: 1.5em; margin-bottom: 1.5em;">
+    <style>
+        .k-editor-gallery-block {
+            margin-top: 1.5em;
+            margin-bottom: 1.5em;
+        }
+        .k-editor-gallery-block-row {
+            display: flex;
+        }
+        .k-editor-gallery-image-wrapper {
+            position: relative;
+        }
+        .k-editor-gallery-image {
+            display: block;
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: 1px;
+        }
+    </style>
+    <div class="k-editor-gallery-block" itemscope itemtype="http://schema.org/ImageGallery">
 <?php endif ?>
 
 <?php if (!empty($images)) : ?>
-    <div class="row" style="position: relative; display: flex;">
+    <div class="k-editor-gallery-block-row">
         <?php
             $rowRatio = 0;
             foreach($images as $image) {
@@ -15,10 +36,10 @@
                 $ratio = ($image['width']) / ($image['height']);
                 $ratioPercent = (($image['height']) / ($image['width'])) * ($ratio / $rowRatio) * 100;
                 $ratioWidth = ($ratio / $rowRatio) * 100;
-                $imageStyle = "position: relative; width: $ratioWidth%; padding-left: 2px; padding-right: 2px; padding-bottom: $ratioPercent%;";
+                $imageStyle = "width: $ratioWidth%; padding-bottom: $ratioPercent%;";
             ?>
-            <div class="k-gallery-block-image" style="<?= $imageStyle ?>">
-                <img style="display: block; position:absolute; width:100%; height:100%; padding: 1px; top:0; left:0;" srcset="<?= $image['image']->srcset([500, 1000, 1500]) ?>" sizes="(max-width: 640px) 500px, (max-width: 1200px) 1000px, 1500px" itemprop="thumbnail" alt="" />
+            <div class="k-editor-gallery-image-wrapper" style="<?= $imageStyle ?>">
+                <img class="k-editor-gallery-image" srcset="<?= $image['image']->srcset([500, 1000, 1500]) ?>" sizes="(max-width: 640px) 500px, (max-width: 1200px) 1000px, 1500px" itemprop="thumbnail" alt="" />
             </div>
         <?php endforeach ?>
     </div>


### PR DESCRIPTION
- makes it easier for users to overwrite the default snippet styles with their own CSS