### PR TITLE
Resolve #18 Avoid commas as decimal separator

### DIFF
--- a/snippets/gallery.php
+++ b/snippets/gallery.php
@@ -36,6 +36,10 @@
                 $ratio = ($image['width']) / ($image['height']);
                 $ratioPercent = (($image['height']) / ($image['width'])) * ($ratio / $rowRatio) * 100;
                 $ratioWidth = ($ratio / $rowRatio) * 100;
+
+                $ratioPercent = str_replace(',','.',$ratioPercent);
+                $ratioWidth = str_replace(',','.',$ratioWidth);
+
                 $imageStyle = "width: $ratioWidth%; padding-bottom: $ratioPercent%;";
             ?>
             <div class="k-editor-gallery-image-wrapper" style="<?= $imageStyle ?>">


### PR DESCRIPTION
e.g. in German language, php prints commas as decimal separators instead of periods.
This results in broken inline CSS code, defining the height of the image.

I assume the `str_replace()` is probably not the best way to resolve that, but will at least solve the problem for now.